### PR TITLE
Add Z.ai GLM provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,16 +69,16 @@ import { Atlas, tavily } from "@steel-dev/atlas";
 
 const zai = createOpenAI({
   apiKey: process.env.ZAI_API_KEY!,
-  baseURL: "https://api.z.ai/api/coding/paas/v4",
+  baseURL: "https://api.z.ai/api/paas/v4",
 });
 
 const atlas = new Atlas({
-  model: zai("GLM-5.2"),
+  model: zai.chat("glm-5.2"),
   search: tavily(),
 });
 ```
 
-The examples also accept `--provider zai` with `ZAI_API_KEY` / `ATLAS_ZAI_API_KEY`. GLM lead models derive `GLM-4.5-Air` for extraction and verification when a Z.ai key is present. Configure `tavily()`, `exa()`, or `brave()` for search; Atlas does not map Z.ai's web-search API to an AI SDK native search tool.
+The examples also accept `--provider zai` with `ZAI_API_KEY` / `ATLAS_ZAI_API_KEY`. GLM lead models derive `glm-4.5-air` for extraction and verification when a Z.ai key is present. Configure `tavily()`, `exa()`, or `brave()` for search; Atlas does not map Z.ai's web-search API to an AI SDK native search tool.
 
 **Concurrency:** `concurrency: { models: 8, io: 10 }` or `ATLAS_MODEL_CONCURRENCY` / `ATLAS_IO_CONCURRENCY`.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,26 @@ const atlas = new Atlas({
 });
 ```
 
-**Models per role:** override `models.extract` / `models.verify` (defaults to a small sibling for Anthropic/OpenAI when keys are present). Screening and entailment checks always run on `models.verify`; at `deep`/`max` the adversarial panel escalates to the lead model with more turns per verifier.
+**Models per role:** override `models.extract` / `models.verify` (defaults to a small sibling for Anthropic/OpenAI/Z.ai when keys are present). Screening and entailment checks always run on `models.verify`; at `deep`/`max` the adversarial panel escalates to the lead model with more turns per verifier.
+
+**Z.ai / GLM:** use Z.ai through its OpenAI-compatible endpoint:
+
+```ts
+import { createOpenAI } from "@ai-sdk/openai";
+import { Atlas, tavily } from "@steel-dev/atlas";
+
+const zai = createOpenAI({
+  apiKey: process.env.ZAI_API_KEY!,
+  baseURL: "https://api.z.ai/api/coding/paas/v4",
+});
+
+const atlas = new Atlas({
+  model: zai("GLM-5.2"),
+  search: tavily(),
+});
+```
+
+The examples also accept `--provider zai` with `ZAI_API_KEY` / `ATLAS_ZAI_API_KEY`. GLM lead models derive `GLM-4.5-Air` for extraction and verification when a Z.ai key is present. Configure `tavily()`, `exa()`, or `brave()` for search; Atlas does not map Z.ai's web-search API to an AI SDK native search tool.
 
 **Concurrency:** `concurrency: { models: 8, io: 10 }` or `ATLAS_MODEL_CONCURRENCY` / `ATLAS_IO_CONCURRENCY`.
 

--- a/examples/cli.ts
+++ b/examples/cli.ts
@@ -20,6 +20,8 @@ import {
 import {
   DEFAULT_ANTHROPIC_MODEL,
   DEFAULT_OPENAI_MODEL,
+  DEFAULT_ZAI_BASE_URL,
+  DEFAULT_ZAI_MODEL,
 } from "../src/defaults.js";
 import { readEnv } from "../src/env.js";
 
@@ -35,7 +37,7 @@ Options:
       --effort LEVEL      fast | balanced | deep | max (default: balanced)
       --budget USD        Spend cap in USD (default: effort envelope)
       --timeout SECONDS   Wall-clock cap; synthesizes what it has near the deadline
-      --provider NAME     anthropic | openai (default: ATLAS_PROVIDER or anthropic)
+      --provider NAME     anthropic | openai | zai (default: ATLAS_PROVIDER or anthropic)
       --model ID          Model id (default: ATLAS_MODEL or provider default)
       --store DIR         Journal the run to DIR (enables --resume)
       --resume RUNID      Resume a parked or failed run from --store
@@ -51,6 +53,8 @@ Environment:
   ATLAS_PROVIDER / ATLAS_MODEL                  default provider and model
   ANTHROPIC_API_KEY or ATLAS_ANTHROPIC_API_KEY  for provider=anthropic
   OPENAI_API_KEY    or ATLAS_OPENAI_API_KEY     for provider=openai
+  ZAI_API_KEY       or ATLAS_ZAI_API_KEY        for provider=zai
+  ZAI_BASE_URL      or ATLAS_ZAI_BASE_URL       optional Z.ai OpenAI-compatible endpoint
   TAVILY_API_KEY / EXA_API_KEY / BRAVE_API_KEY  optional search providers
   STEEL_API_KEY                                 optional fetch escalation
 
@@ -115,22 +119,40 @@ function parseTrace(raw: string | undefined): TraceMode | undefined {
   fail(`--trace must be one of: off, spans, full (got "${raw}")`);
 }
 
+function normalizeProvider(provider: string): "anthropic" | "openai" | "zai" {
+  if (provider === "anthropic" || provider === "openai") return provider;
+  if (provider === "zai" || provider === "z.ai" || provider === "zhipu") {
+    return "zai";
+  }
+  fail(`provider must be one of: anthropic, openai, zai (got "${provider}")`);
+}
+
 function resolveModel(
   providerFlag: string | undefined,
   modelFlag: string | undefined,
 ): AtlasConfig["model"] {
-  const provider = providerFlag ?? readEnv("ATLAS_PROVIDER") ?? "anthropic";
-  if (provider !== "anthropic" && provider !== "openai") {
-    fail(`provider must be one of: anthropic, openai (got "${provider}")`);
-  }
+  const provider = normalizeProvider(
+    providerFlag ?? readEnv("ATLAS_PROVIDER") ?? "anthropic",
+  );
   const modelId =
     modelFlag ??
     readEnv("ATLAS_MODEL") ??
-    (provider === "anthropic" ? DEFAULT_ANTHROPIC_MODEL : DEFAULT_OPENAI_MODEL);
+    (provider === "anthropic"
+      ? DEFAULT_ANTHROPIC_MODEL
+      : provider === "openai"
+        ? DEFAULT_OPENAI_MODEL
+        : DEFAULT_ZAI_MODEL);
   if (provider === "anthropic") {
     const apiKey = readEnv("ATLAS_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY");
     if (!apiKey) fail("ANTHROPIC_API_KEY is required for provider=anthropic");
     return createAnthropic({ apiKey })(modelId);
+  }
+  if (provider === "zai") {
+    const apiKey = readEnv("ATLAS_ZAI_API_KEY", "ZAI_API_KEY");
+    if (!apiKey) fail("ZAI_API_KEY is required for provider=zai");
+    const baseURL =
+      readEnv("ATLAS_ZAI_BASE_URL", "ZAI_BASE_URL") ?? DEFAULT_ZAI_BASE_URL;
+    return createOpenAI({ apiKey, baseURL })(modelId);
   }
   const apiKey = readEnv("ATLAS_OPENAI_API_KEY", "OPENAI_API_KEY");
   if (!apiKey) fail("OPENAI_API_KEY is required for provider=openai");

--- a/examples/cli.ts
+++ b/examples/cli.ts
@@ -152,7 +152,7 @@ function resolveModel(
     if (!apiKey) fail("ZAI_API_KEY is required for provider=zai");
     const baseURL =
       readEnv("ATLAS_ZAI_BASE_URL", "ZAI_BASE_URL") ?? DEFAULT_ZAI_BASE_URL;
-    return createOpenAI({ apiKey, baseURL })(modelId);
+    return createOpenAI({ apiKey, baseURL }).chat(modelId);
   }
   const apiKey = readEnv("ATLAS_OPENAI_API_KEY", "OPENAI_API_KEY");
   if (!apiKey) fail("OPENAI_API_KEY is required for provider=openai");

--- a/examples/serve.ts
+++ b/examples/serve.ts
@@ -12,6 +12,8 @@ import { Atlas, type AtlasConfig, type Effort } from "../src/index.js";
 import {
   DEFAULT_ANTHROPIC_MODEL,
   DEFAULT_OPENAI_MODEL,
+  DEFAULT_ZAI_BASE_URL,
+  DEFAULT_ZAI_MODEL,
 } from "../src/defaults.js";
 import { readEnv } from "../src/env.js";
 
@@ -23,7 +25,7 @@ Usage:
 Options:
       --port N          Port to listen on (default: 4317)
       --host HOST       Host to bind (default: 127.0.0.1)
-      --provider NAME   anthropic | openai (default: ATLAS_PROVIDER or anthropic)
+      --provider NAME   anthropic | openai | zai (default: ATLAS_PROVIDER or anthropic)
       --model ID        Model id (default: ATLAS_MODEL or provider default)
   -h, --help            Show this help
 
@@ -41,22 +43,40 @@ function messageOf(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+function normalizeProvider(provider: string): "anthropic" | "openai" | "zai" {
+  if (provider === "anthropic" || provider === "openai") return provider;
+  if (provider === "zai" || provider === "z.ai" || provider === "zhipu") {
+    return "zai";
+  }
+  fail(`provider must be one of: anthropic, openai, zai (got "${provider}")`);
+}
+
 function resolveModel(
   providerFlag: string | undefined,
   modelFlag: string | undefined,
 ): AtlasConfig["model"] {
-  const provider = providerFlag ?? readEnv("ATLAS_PROVIDER") ?? "anthropic";
-  if (provider !== "anthropic" && provider !== "openai") {
-    fail(`provider must be one of: anthropic, openai (got "${provider}")`);
-  }
+  const provider = normalizeProvider(
+    providerFlag ?? readEnv("ATLAS_PROVIDER") ?? "anthropic",
+  );
   const modelId =
     modelFlag ??
     readEnv("ATLAS_MODEL") ??
-    (provider === "anthropic" ? DEFAULT_ANTHROPIC_MODEL : DEFAULT_OPENAI_MODEL);
+    (provider === "anthropic"
+      ? DEFAULT_ANTHROPIC_MODEL
+      : provider === "openai"
+        ? DEFAULT_OPENAI_MODEL
+        : DEFAULT_ZAI_MODEL);
   if (provider === "anthropic") {
     const apiKey = readEnv("ATLAS_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY");
     if (!apiKey) fail("ANTHROPIC_API_KEY is required for provider=anthropic");
     return createAnthropic({ apiKey })(modelId);
+  }
+  if (provider === "zai") {
+    const apiKey = readEnv("ATLAS_ZAI_API_KEY", "ZAI_API_KEY");
+    if (!apiKey) fail("ZAI_API_KEY is required for provider=zai");
+    const baseURL =
+      readEnv("ATLAS_ZAI_BASE_URL", "ZAI_BASE_URL") ?? DEFAULT_ZAI_BASE_URL;
+    return createOpenAI({ apiKey, baseURL })(modelId);
   }
   const apiKey = readEnv("ATLAS_OPENAI_API_KEY", "OPENAI_API_KEY");
   if (!apiKey) fail("OPENAI_API_KEY is required for provider=openai");

--- a/examples/serve.ts
+++ b/examples/serve.ts
@@ -76,7 +76,7 @@ function resolveModel(
     if (!apiKey) fail("ZAI_API_KEY is required for provider=zai");
     const baseURL =
       readEnv("ATLAS_ZAI_BASE_URL", "ZAI_BASE_URL") ?? DEFAULT_ZAI_BASE_URL;
-    return createOpenAI({ apiKey, baseURL })(modelId);
+    return createOpenAI({ apiKey, baseURL }).chat(modelId);
   }
   const apiKey = readEnv("ATLAS_OPENAI_API_KEY", "OPENAI_API_KEY");
   if (!apiKey) fail("OPENAI_API_KEY is required for provider=openai");

--- a/src/budget.test.ts
+++ b/src/budget.test.ts
@@ -109,6 +109,44 @@ describe("pricing resolution", () => {
     expect(
       resolvePricing("us.anthropic.claude-opus-4-8", DEFAULT_PRICING).known,
     ).toBe(true);
+    expect(resolvePricing("zai.GLM-5.2", DEFAULT_PRICING).known).toBe(true);
+    expect(resolvePricing("zai.glm-5.2", DEFAULT_PRICING).known).toBe(true);
+  });
+
+  it("resolves Z.ai GLM pricing including cached input rates", () => {
+    const { pricing, known } = resolvePricing("GLM-5.2", DEFAULT_PRICING);
+    expect(known).toBe(true);
+    expect(pricing.inputPerMTok).toBe(1.4);
+    expect(pricing.cacheReadPerMTok).toBe(0.26);
+    expect(pricing.cacheWritePerMTok).toBe(0);
+    expect(pricing.outputPerMTok).toBe(4.4);
+
+    const cost = usageCostUSD(
+      {
+        input: 1_000_000,
+        output: 1_000_000,
+        cacheRead: 1_000_000,
+        cacheWrite: 1_000_000,
+      },
+      pricing,
+    );
+    expect(cost).toBeCloseTo(6.06);
+  });
+
+  it("treats free Z.ai Flash models as zero-cost", () => {
+    const { pricing, known } = resolvePricing("GLM-4.5-Flash", DEFAULT_PRICING);
+    expect(known).toBe(true);
+    expect(
+      usageCostUSD(
+        {
+          input: 1_000_000,
+          output: 1_000_000,
+          cacheRead: 1_000_000,
+          cacheWrite: 1_000_000,
+        },
+        pricing,
+      ),
+    ).toBe(0);
   });
 
   it("falls back to conservative pricing for unknown models", () => {

--- a/src/budget.ts
+++ b/src/budget.ts
@@ -29,6 +29,78 @@ export const DEFAULT_PRICING: PricingTable = {
   "o4-mini-deep-research": { inputPerMTok: 2, outputPerMTok: 8 },
   "gemini-2.5-pro": { inputPerMTok: 1.25, outputPerMTok: 10 },
   "gemini-2.5-flash": { inputPerMTok: 0.3, outputPerMTok: 2.5 },
+  "GLM-5.2": {
+    inputPerMTok: 1.4,
+    cacheReadPerMTok: 0.26,
+    cacheWritePerMTok: 0,
+    outputPerMTok: 4.4,
+  },
+  "GLM-5.1": {
+    inputPerMTok: 1.4,
+    cacheReadPerMTok: 0.26,
+    cacheWritePerMTok: 0,
+    outputPerMTok: 4.4,
+  },
+  "GLM-5": {
+    inputPerMTok: 1,
+    cacheReadPerMTok: 0.2,
+    cacheWritePerMTok: 0,
+    outputPerMTok: 3.2,
+  },
+  "GLM-5-Turbo": {
+    inputPerMTok: 1.2,
+    cacheReadPerMTok: 0.24,
+    cacheWritePerMTok: 0,
+    outputPerMTok: 4,
+  },
+  "GLM-4.7": {
+    inputPerMTok: 0.6,
+    cacheReadPerMTok: 0.11,
+    cacheWritePerMTok: 0,
+    outputPerMTok: 2.2,
+  },
+  "GLM-4.7-FlashX": {
+    inputPerMTok: 0.07,
+    cacheReadPerMTok: 0.01,
+    cacheWritePerMTok: 0,
+    outputPerMTok: 0.4,
+  },
+  "GLM-4.6": {
+    inputPerMTok: 0.6,
+    cacheReadPerMTok: 0.11,
+    cacheWritePerMTok: 0,
+    outputPerMTok: 2.2,
+  },
+  "GLM-4.5": {
+    inputPerMTok: 0.6,
+    cacheReadPerMTok: 0.11,
+    cacheWritePerMTok: 0,
+    outputPerMTok: 2.2,
+  },
+  "GLM-4.5-X": {
+    inputPerMTok: 2.2,
+    cacheReadPerMTok: 0.45,
+    cacheWritePerMTok: 0,
+    outputPerMTok: 8.9,
+  },
+  "GLM-4.5-Air": {
+    inputPerMTok: 0.2,
+    cacheReadPerMTok: 0.03,
+    cacheWritePerMTok: 0,
+    outputPerMTok: 1.1,
+  },
+  "GLM-4.5-AirX": {
+    inputPerMTok: 1.1,
+    cacheReadPerMTok: 0.22,
+    cacheWritePerMTok: 0,
+    outputPerMTok: 4.5,
+  },
+  "GLM-4-32B-0414-128K": {
+    inputPerMTok: 0.1,
+    outputPerMTok: 0.1,
+  },
+  "GLM-4.7-Flash": { inputPerMTok: 0, outputPerMTok: 0 },
+  "GLM-4.5-Flash": { inputPerMTok: 0, outputPerMTok: 0 },
 };
 for (const pricing of Object.values(DEFAULT_PRICING)) {
   Object.freeze(pricing);
@@ -66,17 +138,28 @@ export function resolvePricing(
   table: PricingTable,
 ): { pricing: ModelPricing; known: boolean } {
   if (!modelId) return { pricing: UNKNOWN_MODEL_PRICING, known: false };
-  const direct = table[modelId];
+  const lookup = (candidate: string): ModelPricing | undefined => {
+    const direct = table[candidate];
+    if (direct) return direct;
+    const caseInsensitiveKey = Object.keys(table).find(
+      (key) => key.toLowerCase() === candidate.toLowerCase(),
+    );
+    return caseInsensitiveKey ? table[caseInsensitiveKey] : undefined;
+  };
+  const direct = lookup(modelId);
   if (direct) return { pricing: direct, known: true };
   const undated = modelId.replace(/-\d{8}$/, "");
-  if (table[undated]) return { pricing: table[undated], known: true };
+  const undatedPricing = lookup(undated);
+  if (undatedPricing) return { pricing: undatedPricing, known: true };
   const parts = undated.split(".");
   for (let i = 1; i < parts.length; i++) {
-    const candidate = table[parts.slice(i).join(".")];
+    const candidate = lookup(parts.slice(i).join("."));
     if (candidate) return { pricing: candidate, known: true };
   }
   for (const key of Object.keys(table)) {
-    if (undated.startsWith(`${key}-`) || undated.endsWith(`.${key}`)) {
+    const haystack = undated.toLowerCase();
+    const needle = key.toLowerCase();
+    if (haystack.startsWith(`${needle}-`) || haystack.endsWith(`.${needle}`)) {
       return { pricing: table[key], known: true };
     }
   }

--- a/src/defaults.test.ts
+++ b/src/defaults.test.ts
@@ -3,6 +3,7 @@ import type { LanguageModelV3 } from "@ai-sdk/provider";
 import {
   DEFAULT_ANTHROPIC_SMALL_MODEL,
   DEFAULT_OPENAI_SMALL_MODEL,
+  DEFAULT_ZAI_SMALL_MODEL,
   deriveSmallModel,
 } from "./defaults.js";
 import { resolveRunConfig } from "./config.js";
@@ -13,6 +14,10 @@ const ENV_KEYS = [
   "ANTHROPIC_API_KEY",
   "ATLAS_OPENAI_API_KEY",
   "OPENAI_API_KEY",
+  "ATLAS_ZAI_API_KEY",
+  "ZAI_API_KEY",
+  "ATLAS_ZAI_BASE_URL",
+  "ZAI_BASE_URL",
 ];
 
 function fakeModel(provider: string, modelId: string): ResolvedModel {
@@ -63,12 +68,30 @@ describe("deriveSmallModel", () => {
     expect(modelId(derived!)).toBe(DEFAULT_OPENAI_SMALL_MODEL);
   });
 
+  it("derives a GLM Air sibling for Z.ai leads when a key is present", () => {
+    process.env.ZAI_API_KEY = "test-key";
+    const derived = deriveSmallModel(fakeModel("openai.responses", "GLM-5.2"));
+    expect(derived).toBeDefined();
+    expect(modelId(derived!)).toBe(DEFAULT_ZAI_SMALL_MODEL);
+  });
+
+  it("prefers Z.ai derivation for GLM model ids even when using the OpenAI-compatible provider", () => {
+    process.env.ZAI_API_KEY = "test-key";
+    process.env.OPENAI_API_KEY = "test-openai-key";
+    const derived = deriveSmallModel(fakeModel("openai.responses", "GLM-4.5"));
+    expect(derived).toBeDefined();
+    expect(modelId(derived!)).toBe(DEFAULT_ZAI_SMALL_MODEL);
+  });
+
   it("returns undefined without a provider key in the environment", () => {
     expect(
       deriveSmallModel(fakeModel("anthropic.messages", "claude-opus-4-8")),
     ).toBeUndefined();
     expect(
       deriveSmallModel(fakeModel("openai.responses", "gpt-5.5")),
+    ).toBeUndefined();
+    expect(
+      deriveSmallModel(fakeModel("openai.responses", "GLM-5.2")),
     ).toBeUndefined();
   });
 
@@ -81,8 +104,12 @@ describe("deriveSmallModel", () => {
 
   it("returns undefined when the lead is already a small model", () => {
     process.env.ANTHROPIC_API_KEY = "test-key";
+    process.env.ZAI_API_KEY = "test-key";
     expect(
       deriveSmallModel(fakeModel("anthropic.messages", "claude-haiku-4-5")),
+    ).toBeUndefined();
+    expect(
+      deriveSmallModel(fakeModel("openai.responses", "GLM-4.5-Air")),
     ).toBeUndefined();
   });
 });

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -6,13 +6,25 @@ import type { ResolvedModel } from "./model.js";
 
 export const DEFAULT_ANTHROPIC_MODEL = "claude-opus-4-8";
 export const DEFAULT_OPENAI_MODEL = "gpt-5.5";
+export const DEFAULT_ZAI_MODEL = "GLM-5.2";
 export const DEFAULT_ANTHROPIC_SMALL_MODEL = "claude-haiku-4-5";
 export const DEFAULT_OPENAI_SMALL_MODEL = "gpt-5-mini";
+export const DEFAULT_ZAI_SMALL_MODEL = "GLM-4.5-Air";
+export const DEFAULT_ZAI_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
 
 const SMALL_MODEL_ID_PATTERN = /haiku|mini|nano|flash|lite/i;
+const ZAI_MODEL_ID_PATTERN = /^glm-/i;
+const ZAI_SMALL_MODEL_ID_PATTERN = /^glm-4\.5-air$/i;
 
 export function isSmallModelId(modelId: string): boolean {
-  return SMALL_MODEL_ID_PATTERN.test(modelId);
+  return (
+    SMALL_MODEL_ID_PATTERN.test(modelId) ||
+    ZAI_SMALL_MODEL_ID_PATTERN.test(modelId)
+  );
+}
+
+export function isZaiModelId(modelId: string): boolean {
+  return ZAI_MODEL_ID_PATTERN.test(modelId);
 }
 
 export function deriveSmallModel(
@@ -21,8 +33,15 @@ export function deriveSmallModel(
   const inner = lead as LanguageModelV3;
   const provider = (inner.provider ?? "").toLowerCase();
   const modelId = inner.modelId ?? "";
-  if (SMALL_MODEL_ID_PATTERN.test(modelId)) return undefined;
+  if (isSmallModelId(modelId)) return undefined;
   try {
+    if (isZaiModelId(modelId)) {
+      const apiKey = readEnv("ATLAS_ZAI_API_KEY", "ZAI_API_KEY");
+      if (!apiKey) return undefined;
+      const baseURL =
+        readEnv("ATLAS_ZAI_BASE_URL", "ZAI_BASE_URL") ?? DEFAULT_ZAI_BASE_URL;
+      return createOpenAI({ apiKey, baseURL })(DEFAULT_ZAI_SMALL_MODEL);
+    }
     if (provider.includes("anthropic")) {
       const apiKey = readEnv("ATLAS_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY");
       if (!apiKey) return undefined;

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -6,11 +6,11 @@ import type { ResolvedModel } from "./model.js";
 
 export const DEFAULT_ANTHROPIC_MODEL = "claude-opus-4-8";
 export const DEFAULT_OPENAI_MODEL = "gpt-5.5";
-export const DEFAULT_ZAI_MODEL = "GLM-5.2";
+export const DEFAULT_ZAI_MODEL = "glm-5.2";
 export const DEFAULT_ANTHROPIC_SMALL_MODEL = "claude-haiku-4-5";
 export const DEFAULT_OPENAI_SMALL_MODEL = "gpt-5-mini";
-export const DEFAULT_ZAI_SMALL_MODEL = "GLM-4.5-Air";
-export const DEFAULT_ZAI_BASE_URL = "https://api.z.ai/api/coding/paas/v4";
+export const DEFAULT_ZAI_SMALL_MODEL = "glm-4.5-air";
+export const DEFAULT_ZAI_BASE_URL = "https://api.z.ai/api/paas/v4";
 
 const SMALL_MODEL_ID_PATTERN = /haiku|mini|nano|flash|lite/i;
 const ZAI_MODEL_ID_PATTERN = /^glm-/i;
@@ -40,7 +40,7 @@ export function deriveSmallModel(
       if (!apiKey) return undefined;
       const baseURL =
         readEnv("ATLAS_ZAI_BASE_URL", "ZAI_BASE_URL") ?? DEFAULT_ZAI_BASE_URL;
-      return createOpenAI({ apiKey, baseURL })(DEFAULT_ZAI_SMALL_MODEL);
+      return createOpenAI({ apiKey, baseURL }).chat(DEFAULT_ZAI_SMALL_MODEL);
     }
     if (provider.includes("anthropic")) {
       const apiKey = readEnv("ATLAS_ANTHROPIC_API_KEY", "ANTHROPIC_API_KEY");

--- a/src/providers/search.test.ts
+++ b/src/providers/search.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   combineSearchProviders,
   mergeSearchResults,
+  nativeModelSearch,
   type SearchProvider,
   type SearchResult,
 } from "./search.js";
@@ -70,5 +71,21 @@ describe("combineSearchProviders", () => {
     expect(merged).toHaveLength(1);
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toContain("broken");
+  });
+});
+
+describe("nativeModelSearch", () => {
+  it("does not map Z.ai GLM models to OpenAI native web search", async () => {
+    const provider = nativeModelSearch({
+      model: {
+        specificationVersion: "v3",
+        provider: "openai.chat",
+        modelId: "glm-5.2",
+      } as Parameters<typeof nativeModelSearch>[0]["model"],
+    });
+
+    await expect(provider.search({ query: "z.ai" })).rejects.toThrow(
+      /configure a search adapter/,
+    );
   });
 });

--- a/src/providers/search.ts
+++ b/src/providers/search.ts
@@ -1,6 +1,7 @@
 import { generateText, type LanguageModel, type ToolSet } from "ai";
 import { errorMessage } from "../errors.js";
 import { readEnv } from "../env.js";
+import { isZaiModelId } from "../defaults.js";
 import { normalizeUrlForSource } from "../url.js";
 
 export interface SearchResult {
@@ -300,6 +301,11 @@ async function nativeSearchTools(
   model: Exclude<LanguageModel, string>,
 ): Promise<ToolSet> {
   const provider = model.provider.toLowerCase();
+  if (isZaiModelId(model.modelId)) {
+    throw new Error(
+      `nativeModelSearch: provider "${model.provider}" has no known server-side search tool; configure a search adapter (tavily(), exa(), brave())`,
+    );
+  }
   if (provider.includes("anthropic")) {
     const { anthropic } = await import("@ai-sdk/anthropic");
     return {


### PR DESCRIPTION
## Summary
- Add Z.ai/GLM defaults, pricing, and small-model derivation via the OpenAI-compatible chat-completions path
- Add `--provider zai` support to CLI and serve examples
- Prevent GLM models from falling through to OpenAI native web search and document external search adapter usage

## Verification
- `npx vitest run src/providers/search.test.ts src/defaults.test.ts src/budget.test.ts src/model.test.ts`
- Live smoke test with Z.ai + Exa + Steel completed successfully